### PR TITLE
feat: merge SuperKey auth into status card (like APatch)

### DIFF
--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,6 +3,7 @@
     <string name="home">主页</string>
     <string name="learn_more">了解更多</string>
     <string name="home_not_installed">未安装</string>
+    <string name="home_not_installed_or_auth">未安装或未认证</string>
     <string name="home_click_to_install">点击安装</string>
     <string name="home_working">工作中</string>
     <string name="home_working_version">版本：%s</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="home">Home</string>
     <string name="learn_more">Learn more</string>
     <string name="home_not_installed">Not installed</string>
+    <string name="home_not_installed_or_auth">Not installed or not authenticated</string>
     <string name="home_click_to_install">Click to install</string>
     <string name="home_working">Working</string>
     <string name="home_working_version">Version: %s</string>


### PR DESCRIPTION
将 SuperKey 认证卡片合并到状态卡片中，类似 APatch 的设计：
- 状态卡片增加 needsSuperKeyAuth 参数
- 需要认证时显示 Key 图标和"未安装或未认证"文案
- 点击卡片触发认证对话框
- 移除独立的 SuperKeyAuthCard 组件