### PR TITLE
feat(gki): add GKI yield mechanism for LKM takeover

### DIFF
--- a/kernel/ksu.h
+++ b/kernel/ksu.h
@@ -9,6 +9,10 @@
 
 extern bool ksu_uid_scanner_enabled;
 
+// GKI yield support: when LKM takes over, GKI should yield
+extern bool ksu_is_active;
+int ksu_yield(void);  // Called by LKM to make GKI yield
+
 #define EVENT_POST_FS_DATA 1
 #define EVENT_BOOT_COMPLETED 2
 #define EVENT_MODULE_MOUNTED 3

--- a/kernel/ksu.h
+++ b/kernel/ksu.h
@@ -11,6 +11,7 @@ extern bool ksu_uid_scanner_enabled;
 
 // GKI yield support: when LKM takes over, GKI should yield
 extern bool ksu_is_active;
+extern bool ksu_initialized;  // true when GKI is fully initialized
 int ksu_yield(void);  // Called by LKM to make GKI yield
 
 #define EVENT_POST_FS_DATA 1

--- a/kernel/pkg_observer.c
+++ b/kernel/pkg_observer.c
@@ -149,7 +149,12 @@ int ksu_observer_init(void)
 
 void ksu_observer_exit(void)
 {
+	if (!g) {
+		pr_info("%s: not initialized, skipping\n", __func__);
+		return;
+	}
 	unwatch_one_dir(&g_watch);
 	fsnotify_put_group(g);
+	g = NULL;
 	pr_info("%s: done.\n", __func__);
 }


### PR DESCRIPTION
## Summary
Add GKI yield mechanism to allow LKM to gracefully take over from GKI when both are present.

## Changes

### Kernel (GKI side)
- Add `ksu_yield()` function that performs cleanup and marks GKI as inactive
- Add `ksu_is_active` and `ksu_initialized` flags for LKM to detect GKI state
- Export symbols via `kallsyms` for LKM discovery
- Clean up observers, hooks, and allowlist when yielding
- Add NULL check in `ksu_observer_exit()` to prevent crash

### Key Features
- GKI can detect when LKM wants to take over
- Graceful cleanup of fsnotify observers and hooks
- Thread-safe state management with proper synchronization

## Testing
- Tested on real device with GKI kernel + LKM module
- Successfully boots with LKM taking over from GKI