### PR TITLE
feat(lkm): add configurable LKM priority over GKI with manager UI

### DIFF
--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Flash.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Flash.kt
@@ -829,7 +829,8 @@ sealed class FlashIt : Parcelable {
         val ota: Boolean, 
         val partition: String? = null,
         val superKey: String? = null,
-        val signatureBypass: Boolean = false
+        val signatureBypass: Boolean = false,
+        val gkiPriority: Boolean = false
     ) : FlashIt()
     data class FlashModule(val uri: Uri) : FlashIt()
     data class FlashModules(val uris: List<Uri>, val currentIndex: Int = 0) : FlashIt()
@@ -862,6 +863,7 @@ fun flashIt(
             flashIt.partition,
             flashIt.superKey,
             flashIt.signatureBypass,
+            flashIt.gkiPriority,
             onFinish,
             onStdout,
             onStderr

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
@@ -143,6 +143,8 @@ fun InstallScreen(
     var showSuperKeyInput by remember { mutableStateOf(false) }
     // Signature bypass - when enabled, only SuperKey authentication works
     var signatureBypass by remember { mutableStateOf(false) }
+    // GKI priority - when enabled, GKI takes priority over LKM (LKM will not trigger yield)
+    var gkiPriority by remember { mutableStateOf(false) }
 
     val onInstall = {
         installMethod?.let { method ->
@@ -168,7 +170,8 @@ fun InstallScreen(
                         ota = isOta,
                         partition = partitionSelection,
                         superKey = superKey.ifBlank { null },
-                        signatureBypass = signatureBypass
+                        signatureBypass = signatureBypass,
+                        gkiPriority = gkiPriority
                     )
                     navigator.navigate(FlashScreenDestination(flashIt))
                 }
@@ -513,6 +516,32 @@ fun InstallScreen(
                                     checked = signatureBypass,
                                     onCheckedChange = { signatureBypass = it },
                                     enabled = superKey.isNotBlank()
+                                )
+                            }
+                            
+                            // GKI priority switch
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = stringResource(id = R.string.gki_priority_title),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                                    )
+                                    Text(
+                                        text = stringResource(id = R.string.gki_priority_desc),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                                    )
+                                }
+                                Switch(
+                                    checked = gkiPriority,
+                                    onCheckedChange = { gkiPriority = it }
                                 )
                             }
                         }

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
@@ -518,32 +518,49 @@ fun InstallScreen(
                                     enabled = superKey.isNotBlank()
                                 )
                             }
-                            
-                            // GKI priority switch
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 12.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.SpaceBetween
-                            ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = stringResource(id = R.string.gki_priority_title),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onTertiaryContainer
-                                    )
-                                    Text(
-                                        text = stringResource(id = R.string.gki_priority_desc),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
-                                    )
-                                }
-                                Switch(
-                                    checked = gkiPriority,
-                                    onCheckedChange = { gkiPriority = it }
+                        }
+                    }
+                }
+
+                // GKI priority switch card (独立显示，适用于所有 LKM 安装模式)
+                AnimatedVisibility(
+                    visible = installMethod is InstallMethod.DirectInstall || 
+                              installMethod is InstallMethod.DirectInstallToInactiveSlot ||
+                              installMethod is InstallMethod.SelectFile,
+                    enter = fadeIn() + expandVertically(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    ElevatedCard(
+                        colors = getCardColors(MaterialTheme.colorScheme.secondaryContainer),
+                        elevation = getCardElevation(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 12.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(id = R.string.gki_priority_title),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                                Text(
+                                    text = stringResource(id = R.string.gki_priority_desc),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                                    modifier = Modifier.padding(top = 4.dp)
                                 )
                             }
+                            Switch(
+                                checked = gkiPriority,
+                                onCheckedChange = { gkiPriority = it }
+                            )
                         }
                     }
                 }

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/util/KsuCli.kt
@@ -312,6 +312,7 @@ fun installBoot(
     partition: String?,
     superKey: String? = null,
     signatureBypass: Boolean = false,
+    gkiPriority: Boolean = false,
     onFinish: (Boolean, Int) -> Unit,
     onStdout: (String) -> Unit,
     onStderr: (String) -> Unit,
@@ -350,6 +351,11 @@ fun installBoot(
         if (signatureBypass) {
             cmd += " --signature-bypass"
         }
+    }
+
+    // Add GKI priority flag if enabled (disables LKM priority)
+    if (gkiPriority) {
+        cmd += " --lkm-priority=false"
     }
 
     var lkmFile: File? = null

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -545,8 +545,19 @@
     <string name="selected_apps_count">%1$d 个已选应用</string>
     <string name="already_added_apps_count">%1$d 个已添加应用</string>
     <string name="all_apps_already_added">所有应用均已添加</string>
+    <string name="dynamic_manager_title">动态管理器配置</string>
+    <string name="dynamic_manager_enabled_summary">已启用（大小: %s）</string>
+    <string name="dynamic_manager_disabled">未启用</string>
+    <string name="enable_dynamic_manager">启用动态管理器</string>
+    <string name="signature_size">动态管理器签名大小</string>
+    <string name="signature_hash">动态管理器签名哈希值</string>
     <string name="hash_must_be_64_chars">哈希值必须是 64 位十六进制字符</string>
+    <string name="dynamic_manager_set_success">动态管理器配置设置成功</string>
+    <string name="dynamic_manager_set_failed">动态管理器配置设置失败</string>
     <string name="invalid_sign_config">无效的签名配置</string>
+    <string name="dynamic_manager_disabled_success">动态管理器已禁用</string>
+    <string name="dynamic_manager_clear_failed">清除动态管理器错误</string>
+    <string name="dynamic_managerature">动态</string>
     <string name="signature_index">签名 %1$d</string>
     <string name="unknown_signature">未知</string>
     <string name="multi_manager_list">活跃管理器</string>
@@ -722,4 +733,6 @@
     <string name="settings_clear_super_key_dialog">确定要清除已存储的超级密钥吗？</string>
     <string name="signature_bypass_title">仅超级密钥模式</string>
     <string name="signature_bypass_desc">禁用 APK 签名验证。管理器将仅通过超级密钥认证来识别。</string>
+    <string name="gki_priority_title">GKI 优先模式</string>
+    <string name="gki_priority_desc">启用后，GKI 优先于 LKM。LKM 将不会触发 GKI 让位，两者独立运行。</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -719,4 +719,6 @@
     <string name="settings_donot_store_superkey_summary">啟用後，管理器不會儲存您的超級密鑰。每次重新啟動後都需要手動輸入密鑰進行認證。</string>
     <string name="signature_bypass_title">僅超級密鑰模式</string>
     <string name="signature_bypass_desc">停用 APK 簽名驗證。管理器將僅透過超級密鑰認證來識別。</string>
+    <string name="gki_priority_title">GKI 優先模式</string>
+    <string name="gki_priority_desc">啟用後，GKI 優先於 LKM。LKM 將不會觸發 GKI 讓位，兩者獨立運作。</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -544,8 +544,19 @@
     <string name="selected_apps_count">%1$d apps selected</string>
     <string name="already_added_apps_count">%1$d apps already added</string>
     <string name="all_apps_already_added">All apps have been added</string>
+    <string name="dynamic_manager_title">Dynamic Manager Configuration</string>
+    <string name="dynamic_manager_enabled_summary">Enabled (Size: %s)</string>
+    <string name="dynamic_manager_disabled">Disabled</string>
+    <string name="enable_dynamic_manager">Enable Dynamic Manager</string>
+    <string name="signature_size">Dynamic Manager Signature Size</string>
+    <string name="signature_hash">Dynamic Manager Signature Hash</string>
     <string name="hash_must_be_64_chars">Hash must be 64 hexadecimal characters</string>
+    <string name="dynamic_manager_set_success">Dynamic Manager configuration set successfully</string>
+    <string name="dynamic_manager_set_failed">Failed to set dynamic Manager configuration</string>
     <string name="invalid_sign_config">Invalid Manager configuration</string>
+    <string name="dynamic_manager_disabled_success">Dynamic Manager disabled</string>
+    <string name="dynamic_manager_clear_failed">Failed to clear dynamic Manager</string>
+    <string name="dynamic_managerature">Dynamic</string>
     <string name="signature_index">Signature %1$d</string>
     <string name="unknown_signature">Unknown</string>
     <string name="multi_manager_list">Active Manager</string>
@@ -727,5 +738,7 @@ Important Note:\n
     <string name="settings_clear_super_key_dialog">Do you really want to clear the stored SuperKey?</string>
     <string name="signature_bypass_title">SuperKey Only Mode</string>
     <string name="signature_bypass_desc">Disable APK signature verification. Manager will only be recognized through SuperKey authentication.</string>
+    <string name="gki_priority_title">GKI Priority Mode</string>
+    <string name="gki_priority_desc">When enabled, GKI takes priority over LKM. The LKM will not trigger GKI yield and both will run independently.</string>
 </resources>
 

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -22,6 +22,10 @@ const SUPERKEY_MAGIC: u64 = 0x5355504552; // "SUPER" in hex
 // SuperKey flags bit definitions
 const SUPERKEY_FLAG_SIGNATURE_BYPASS: u64 = 1; // bit 0: disable signature verification
 
+// LKM Priority magic marker (must match kernel's LKM_PRIORITY_MAGIC)
+// "LKMPRIO" in hex (little-endian)
+const LKM_PRIORITY_MAGIC: u64 = 0x4F4952504D4B4C;
+
 /// Calculate superkey hash using the same algorithm as kernel
 fn hash_superkey(key: &str) -> u64 {
     let mut hash: u64 = 1000000007;
@@ -71,6 +75,54 @@ fn inject_superkey_to_lkm(lkm_path: &Path, superkey: &str, signature_bypass: boo
     if !found {
         println!("- Warning: SUPERKEY_MAGIC not found in LKM, SuperKey may not work");
         println!("- Make sure the kernel module is compiled with SuperKey support");
+    } else {
+        // Write back the patched content
+        file.seek(SeekFrom::Start(0))?;
+        file.write_all(&content)?;
+        file.sync_all()?;
+    }
+    
+    Ok(())
+}
+
+/// Inject LKM priority setting into the kernel module
+/// When enabled is true, LKM will have priority over GKI (will trigger GKI yield)
+/// When enabled is false, LKM will not trigger GKI yield, both will run independently
+fn inject_lkm_priority_to_lkm(lkm_path: &Path, enabled: bool) -> Result<()> {
+    let enabled_value: u32 = if enabled { 1 } else { 0 };
+    println!("- LKM priority over GKI: {}", enabled);
+    
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(lkm_path)
+        .context("Failed to open LKM file for priority patching")?;
+    
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    
+    // Search for LKM_PRIORITY_MAGIC in the binary
+    let magic_bytes = LKM_PRIORITY_MAGIC.to_le_bytes();
+    let mut found = false;
+    
+    // Structure in kernel:
+    // offset 0: magic (u64)
+    // offset 8: enabled (u32)
+    // offset 12: reserved (u32)
+    for i in 0..content.len().saturating_sub(16) {
+        if content[i..i+8] == magic_bytes {
+            // Found magic, patch the enabled field at offset +8
+            let enabled_bytes = enabled_value.to_le_bytes();
+            content[i+8..i+12].copy_from_slice(&enabled_bytes);
+            found = true;
+            println!("- Injected LKM priority config at offset 0x{:x}", i);
+            break;
+        }
+    }
+    
+    if !found {
+        println!("- Warning: LKM_PRIORITY_MAGIC not found in LKM");
+        println!("- This LKM may not support GKI yield mechanism");
     } else {
         // Write back the patched content
         file.seek(SeekFrom::Start(0))?;
@@ -533,6 +585,12 @@ pub struct BootPatchArgs {
     #[arg(long, default_value = "false")]
     pub signature_bypass: bool,
 
+    /// LKM priority over GKI (default: true)
+    /// When enabled, LKM will trigger GKI yield and take over
+    /// When disabled, both GKI and LKM will run independently
+    #[arg(long, default_value = "true")]
+    pub lkm_priority: bool,
+
     /// will use another slot when boot image is not specified
     #[cfg(target_os = "android")]
     #[arg(short = 'u', long, default_value = "false")]
@@ -578,6 +636,7 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             out_name,
             superkey,
             signature_bypass,
+            lkm_priority,
             ..
         } = args;
         #[cfg(target_os = "android")]
@@ -683,6 +742,10 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         } else if signature_bypass {
             println!("- Warning: signature_bypass requires superkey to be set, ignoring");
         }
+
+        // Inject LKM priority setting into LKM
+        println!("- Configuring LKM priority");
+        inject_lkm_priority_to_lkm(&kmod_file, lkm_priority)?;
 
         let init_file = workdir.join("init");
         if let Some(init) = init {

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -588,7 +588,7 @@ pub struct BootPatchArgs {
     /// LKM priority over GKI (default: true)
     /// When enabled, LKM will trigger GKI yield and take over
     /// When disabled, both GKI and LKM will run independently
-    #[arg(long, default_value = "true")]
+    #[arg(long, default_value_t = true, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
     pub lkm_priority: bool,
 
     /// will use another slot when boot image is not specified

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -110,13 +110,14 @@ pub fn init() -> Result<()> {
     // This relies on the fact that we have /proc mounted
     unlimit_kmsg();
 
+    // LKM priority mode: always load LKM even if GKI exists
+    // GKI will yield when LKM sends YIELD command
     if has_kernelsu() {
-        log::info!("KernelSU may be already loaded in kernel, skip!");
-    } else {
-        log::info!("Loading kernelsu.ko..");
-        if let Err(e) = load_module("/kernelsu.ko") {
-            log::error!("Cannot load kernelsu.ko: {:?}", e);
-        }
+        log::info!("KernelSU GKI detected, LKM will take over...");
+    }
+    log::info!("Loading kernelsu.ko..");
+    if let Err(e) = load_module("/kernelsu.ko") {
+        log::error!("Cannot load kernelsu.ko: {:?}", e);
     }
 
     // And now we should prepare the real init to transfer control to it


### PR DESCRIPTION
## Summary
Add user-configurable LKM priority mechanism that allows users to choose whether LKM takes over from GKI or both run independently.

## Changes

### Kernel (LKM side)
- Add `LKM_PRIORITY_MAGIC` (0x4F4952504D4B4C) for ksud patching
- Add `lkm_priority_config` struct with magic, enabled, and reserved fields
- Add `ksu_lkm_priority_enabled()` to check if LKM should take over GKI
- Modify `try_yield_gki()` to respect `lkm_priority_enabled` setting
- Use `delayed_work` for GKI yield to avoid blocking in module_init

### ksud (boot_patch.rs)
- Add `--lkm-priority` CLI option (default: true)
- Add `inject_lkm_priority_to_lkm()` function to patch LKM binary

### Manager UI
- Add "GKI Priority Mode" switch in LKM installation page
- Pass `--lkm-priority=false` to ksud when switch is enabled
- Add string resources (en, zh-CN, zh-TW)

## Behavior

| Switch | Behavior |
|--------|----------|
| Off (default) | LKM priority - LKM triggers GKI yield and takes over |
| On | GKI priority - Both run independently |

## Testing
- Tested LKM installation with both modes
- Successfully verified GKI yield mechanism works when enabled