### PR TITLE
Add forward declaration for task_struct

### DIFF
--- a/kernel/app_profile.h
+++ b/kernel/app_profile.h
@@ -5,6 +5,7 @@
 
 // Forward declarations
 struct cred;
+struct task_struct;
 
 #define KSU_APP_PROFILE_VER 2
 #define KSU_MAX_PACKAGE_NAME 256


### PR DESCRIPTION
Fixes compilation on GKI kernels. Let me know if the PR should be targeting another branch, such as `builtin`.