### PR TITLE
Implement HymoFS embedding in cpio and UI enhancements

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -82,6 +82,8 @@ static int do_get_info(void __user *arg)
 {
 	struct ksu_get_info_cmd cmd = {.version = KERNEL_SU_VERSION,
 				       .flags = 0};
+	uid_t cur_uid = current_uid().val;
+	uid_t cur_appid = cur_uid % PER_USER_RANGE;
 
 #ifdef MODULE
 	cmd.flags |= 0x1;
@@ -90,6 +92,10 @@ static int do_get_info(void __user *arg)
 		cmd.flags |= 0x2;
 	}
 	cmd.features = KSU_FEATURE_MAX;
+	pr_info("get_info: uid=%u appid=%u is_manager=%d flags=0x%x mgr0=%u "
+		"mgr1=%u\n",
+		cur_uid, cur_appid, is_manager() ? 1 : 0, cmd.flags,
+		ksu_manager_appids[0], ksu_manager_appids[1]);
 
 	if (copy_to_user(arg, &cmd, sizeof(cmd))) {
 		pr_err("get_version: copy_to_user failed\n");

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -82,8 +82,6 @@ static int do_get_info(void __user *arg)
 {
 	struct ksu_get_info_cmd cmd = {.version = KERNEL_SU_VERSION,
 				       .flags = 0};
-	uid_t cur_uid = current_uid().val;
-	uid_t cur_appid = cur_uid % PER_USER_RANGE;
 
 #ifdef MODULE
 	cmd.flags |= 0x1;
@@ -92,10 +90,6 @@ static int do_get_info(void __user *arg)
 		cmd.flags |= 0x2;
 	}
 	cmd.features = KSU_FEATURE_MAX;
-	pr_info("get_info: uid=%u appid=%u is_manager=%d flags=0x%x mgr0=%u "
-		"mgr1=%u\n",
-		cur_uid, cur_appid, is_manager() ? 1 : 0, cmd.flags,
-		ksu_manager_appids[0], ksu_manager_appids[1]);
 
 	if (copy_to_user(arg, &cmd, sizeof(cmd))) {
 		pr_err("get_version: copy_to_user failed\n");

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -68,9 +68,6 @@ void ksu_set_manager_appid_for_index(uid_t appid, int signature_index)
 		if (ksu_manager_appids[i] == KSU_INVALID_UID) {
 			ksu_manager_appids[i] = appid;
 			locked_manager_appids[i] = appid;
-			pr_info("Manager slot collision on signature_index=%d, "
-				"placed appid=%u into slot=%d\n",
-				signature_index, appid, i);
 			update_primary_manager();
 			return;
 		}

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -7,6 +7,7 @@
 #include <linux/version.h>
 
 #include "allowlist.h"
+#include "apk_sign.h"
 #include "klog.h" // IWYU pragma: keep
 #include "manager.h"
 #include "throne_tracker.h"
@@ -446,7 +447,7 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 {
 	struct list_head *list = (struct list_head *)data;
 	struct uid_data *np;
-	u32 appid = uid % 100000;
+	u32 appid = uid % PER_USER_RANGE;
 	bool exist = false;
 
 	list_for_each_entry (np, list, list) {
@@ -461,7 +462,6 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 
 void track_throne(bool prune_only)
 {
-	pr_info("track_throne: opening packages.list...\n");
 	struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n",
@@ -476,7 +476,6 @@ void track_throne(bool prune_only)
 	loff_t pos = 0;
 	char buf[KSU_MAX_PACKAGE_NAME];
 	int buf_idx = 0;
-	int lines_read = 0;
 	for (;;) {
 		ssize_t count = kernel_read(fp, &chr, sizeof(chr), &pos);
 		if (count != sizeof(chr))
@@ -518,15 +517,14 @@ void track_throne(bool prune_only)
 			// Skip invalid uid
 			continue;
 		}
-		data->appid = res;
+		/* packages.list second column is full userId; use appid for
+		 * multi-user correctness */
+		data->appid = res % PER_USER_RANGE;
 		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
 		list_add_tail(&data->list, &uid_list);
-		lines_read++;
 	}
 
 	filp_close(fp, 0);
-	pr_info("track_throne: finished reading packages.list, read %d lines\n",
-		lines_read);
 
 	// now update uid list
 	struct uid_data *np;
@@ -562,16 +560,37 @@ void track_throne(bool prune_only)
 		update_primary_manager();
 	}
 	{
-		bool manager_exist = (ksu_manager_appid != KSU_INVALID_UID);
-		bool need_search;
+		bool manager_exist = false;
+		int i;
+
+		for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++) {
+			uid_t aid = ksu_manager_appids[i];
+			if (aid == KSU_INVALID_UID)
+				continue;
+			list_for_each_entry (np, &uid_list, list) {
+				if (np->appid == aid) {
+					manager_exist = true;
+					break;
+				}
+			}
+			if (manager_exist)
+				break;
+		}
+
 		if (!manager_exist) {
+			if (ksu_is_manager_appid_valid()) {
+				pr_info(
+				    "manager is uninstalled, invalidate it!\n");
+				ksu_invalidate_manager_appid();
+				for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++)
+					locked_manager_appids[i] =
+					    KSU_INVALID_UID;
+				goto prune;
+			}
 #ifdef CONFIG_KSU_SUPERKEY
 			extern void ksu_superkey_register_prctl_kprobe(void);
 			ksu_superkey_register_prctl_kprobe();
 #endif // #ifdef CONFIG_KSU_SUPERKEY
-		}
-		need_search = !manager_exist;
-		if (need_search) {
 			pr_info("Searching for manager(s)...\n");
 			search_manager("/data/app", 2, &uid_list);
 			pr_info("Manager search finished\n");

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -7,7 +7,6 @@
 #include <linux/version.h>
 
 #include "allowlist.h"
-#include "apk_sign.h"
 #include "klog.h" // IWYU pragma: keep
 #include "manager.h"
 #include "throne_tracker.h"
@@ -447,7 +446,7 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 {
 	struct list_head *list = (struct list_head *)data;
 	struct uid_data *np;
-	u32 appid = uid % PER_USER_RANGE;
+	u32 appid = uid % 100000;
 	bool exist = false;
 
 	list_for_each_entry (np, list, list) {
@@ -462,6 +461,7 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 
 void track_throne(bool prune_only)
 {
+	pr_info("track_throne: opening packages.list...\n");
 	struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n",
@@ -476,6 +476,7 @@ void track_throne(bool prune_only)
 	loff_t pos = 0;
 	char buf[KSU_MAX_PACKAGE_NAME];
 	int buf_idx = 0;
+	int lines_read = 0;
 	for (;;) {
 		ssize_t count = kernel_read(fp, &chr, sizeof(chr), &pos);
 		if (count != sizeof(chr))
@@ -517,14 +518,15 @@ void track_throne(bool prune_only)
 			// Skip invalid uid
 			continue;
 		}
-		/* packages.list second column is full userId; use appid for
-		 * multi-user correctness */
-		data->appid = res % PER_USER_RANGE;
+		data->appid = res;
 		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
 		list_add_tail(&data->list, &uid_list);
+		lines_read++;
 	}
 
 	filp_close(fp, 0);
+	pr_info("track_throne: finished reading packages.list, read %d lines\n",
+		lines_read);
 
 	// now update uid list
 	struct uid_data *np;
@@ -560,41 +562,23 @@ void track_throne(bool prune_only)
 		update_primary_manager();
 	}
 	{
-		bool manager_exist = false;
-		int i;
-
-		for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++) {
-			uid_t aid = ksu_manager_appids[i];
-			if (aid == KSU_INVALID_UID)
-				continue;
-			list_for_each_entry (np, &uid_list, list) {
-				if (np->appid == aid) {
-					manager_exist = true;
-					break;
-				}
-			}
-			if (manager_exist)
-				break;
-		}
-
+		bool manager_exist = (ksu_manager_appid != KSU_INVALID_UID);
+		pr_info(
+		    "track_throne: ksu_manager_appid=%d, KSU_INVALID_UID=%d\n",
+		    ksu_manager_appid, KSU_INVALID_UID);
 		if (!manager_exist) {
-			if (ksu_is_manager_appid_valid()) {
-				pr_info(
-				    "manager is uninstalled, invalidate it!\n");
-				ksu_invalidate_manager_appid();
-				for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++)
-					locked_manager_appids[i] =
-					    KSU_INVALID_UID;
-				goto prune;
-			}
 #ifdef CONFIG_KSU_SUPERKEY
 			extern void ksu_superkey_register_prctl_kprobe(void);
 			ksu_superkey_register_prctl_kprobe();
 #endif // #ifdef CONFIG_KSU_SUPERKEY
-			pr_info("Searching for manager(s)...\n");
-			search_manager("/data/app", 2, &uid_list);
-			pr_info("Manager search finished\n");
 		}
+		/*
+		 * Always rescan /data/app to avoid stale manager_appid
+		 * after app reinstall / appid reuse.
+		 */
+		pr_info("Searching for manager(s)...\n");
+		search_manager("/data/app", 2, &uid_list);
+		pr_info("Manager search finished\n");
 	}
 
 prune:

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -461,6 +461,7 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 
 void track_throne(bool prune_only)
 {
+	pr_info("track_throne: opening packages.list...\n");
 	struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n",
@@ -473,24 +474,26 @@ void track_throne(bool prune_only)
 
 	char chr = 0;
 	loff_t pos = 0;
-	loff_t line_start = 0;
 	char buf[KSU_MAX_PACKAGE_NAME];
+	int buf_idx = 0;
+	int lines_read = 0;
 	for (;;) {
 		ssize_t count = kernel_read(fp, &chr, sizeof(chr), &pos);
 		if (count != sizeof(chr))
 			break;
-		if (chr != '\n')
-			continue;
-
-		size_t line_len = pos - line_start - 1; // Exclude '\n'
-		if (line_len >= sizeof(buf)) {
-			// Line too long, skip it
-			line_start = pos;
+		if (chr != '\n') {
+			if (buf_idx < sizeof(buf) - 1) {
+				buf[buf_idx++] = chr;
+			}
 			continue;
 		}
 
-		count = kernel_read(fp, buf, line_len, &line_start);
-		buf[line_len] = '\0'; // Null-terminate the string
+		// Line finished
+		buf[buf_idx] = '\0';
+		buf_idx = 0; // Reset for next line
+
+		if (strlen(buf) == 0)
+			continue;
 
 		struct uid_data *data =
 		    kzalloc(sizeof(struct uid_data), GFP_ATOMIC);
@@ -505,24 +508,25 @@ void track_throne(bool prune_only)
 		char *uid = strsep(&tmp, delim);
 		if (!uid || !package) {
 			kfree(data);
-			pr_err("update_uid: package or uid is NULL!\n");
-			break;
+			// Probably not a valid line, just skip
+			continue;
 		}
 
 		u32 res;
 		if (kstrtou32(uid, 10, &res)) {
 			kfree(data);
-			pr_err("track_throne: appid parse err\n");
-			break;
+			// Skip invalid uid
+			continue;
 		}
 		data->appid = res;
 		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
 		list_add_tail(&data->list, &uid_list);
-		// reset line start
-		line_start = pos;
+		lines_read++;
 	}
 
 	filp_close(fp, 0);
+	pr_info("track_throne: finished reading packages.list, read %d lines\n",
+		lines_read);
 
 	// now update uid list
 	struct uid_data *np;

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -187,14 +187,14 @@ static void crown_manager(const char *apk, struct list_head *uid_data,
 		return;
 	}
 
-	pr_info("manager pkg: %s\n", pkg);
+	pr_info("manager pkg: %s, signature_index: %d\n", pkg, signature_index);
 
 #ifdef KSU_MANAGER_PACKAGE
 	// pkg is `/<real package>`
 	if (strncmp(pkg, KSU_MANAGER_PACKAGE, sizeof(KSU_MANAGER_PACKAGE))) {
-		pr_info(
-		    "manager package is inconsistent with kernel build: %s\n",
-		    KSU_MANAGER_PACKAGE);
+		pr_info("manager package is inconsistent with kernel build: %s "
+			"vs %s\n",
+			pkg, KSU_MANAGER_PACKAGE);
 		return;
 	}
 #endif // #ifdef KSU_MANAGER_PACKAGE
@@ -203,8 +203,10 @@ static void crown_manager(const char *apk, struct list_head *uid_data,
 
 	list_for_each_entry (np, list, list) {
 		if (strncmp(np->package, pkg, KSU_MAX_PACKAGE_NAME) == 0) {
-			pr_info("Crowning manager: %s(appid=%d)\n", pkg,
-				np->appid);
+			pr_info("Crowning manager: %s (appid=%d) "
+				"signature_index=%d\n",
+				pkg, np->appid, signature_index);
+
 			if (signature_index >= 0 &&
 			    signature_index < KSU_MAX_MANAGER_KEYS) {
 				ksu_set_manager_appid_for_index(

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -500,76 +500,69 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 
 void track_throne(bool prune_only)
 {
-	pr_info("track_throne: opening packages.list...\n");
-	struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
+	struct list_head uid_list;
+	struct uid_data *np, *n;
+	struct file *fp;
+	char chr = 0;
+	loff_t pos = 0;
+	loff_t line_start = 0;
+	char buf[KSU_MAX_PACKAGE_NAME];
+	static bool manager_exist = false;
+	bool need_search = false;
+
+	// init uid list head
+	INIT_LIST_HEAD(&uid_list);
+
+	fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n",
 		       __func__, PTR_ERR(fp));
 		return;
 	}
 
-	struct list_head uid_list;
-	INIT_LIST_HEAD(&uid_list);
-
-	char chr = 0;
-	loff_t pos = 0;
-	char buf[KSU_MAX_PACKAGE_NAME];
-	int buf_idx = 0;
-	int lines_read = 0;
 	for (;;) {
+		struct uid_data *data = NULL;
 		ssize_t count = kernel_read(fp, &chr, sizeof(chr), &pos);
+		const char *delim = " ";
+		char *package = NULL;
+		char *tmp = NULL;
+		char *uid = NULL;
+		u32 res;
+
 		if (count != sizeof(chr))
 			break;
-		if (chr != '\n') {
-			if (buf_idx < sizeof(buf) - 1) {
-				buf[buf_idx++] = chr;
-			}
-			continue;
-		}
-
-		// Line finished
-		buf[buf_idx] = '\0';
-		buf_idx = 0; // Reset for next line
-
-		if (strlen(buf) == 0)
+		if (chr != '\n')
 			continue;
 
-		struct uid_data *data =
-		    kzalloc(sizeof(struct uid_data), GFP_ATOMIC);
+		count = kernel_read(fp, buf, sizeof(buf), &line_start);
+		data = kzalloc(sizeof(struct uid_data), GFP_ATOMIC);
 		if (!data) {
 			filp_close(fp, 0);
 			goto out;
 		}
 
-		char *tmp = buf;
-		const char *delim = " ";
-		char *package = strsep(&tmp, delim);
-		char *uid = strsep(&tmp, delim);
+		tmp = buf;
+		package = strsep(&tmp, delim);
+		uid = strsep(&tmp, delim);
 		if (!uid || !package) {
 			kfree(data);
-			// Probably not a valid line, just skip
-			continue;
+			pr_err("update_uid: package or uid is NULL!\n");
+			break;
 		}
 
-		u32 res;
 		if (kstrtou32(uid, 10, &res)) {
 			kfree(data);
-			// Skip invalid uid
-			continue;
+			pr_err("track_throne: appid parse err\n");
+			break;
 		}
 		data->appid = res;
 		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
 		list_add_tail(&data->list, &uid_list);
-		lines_read++;
+		// reset line start
+		line_start = pos;
 	}
 
 	filp_close(fp, 0);
-	pr_info("track_throne: finished reading packages.list, read %d lines\n",
-		lines_read);
-
-	// now update uid list
-	struct uid_data *np;
-	struct uid_data *n;
 
 	if (prune_only)
 		goto prune;
@@ -599,22 +592,18 @@ void track_throne(bool prune_only)
 			}
 		}
 		update_primary_manager();
-	}
-	{
-		bool manager_exist = (ksu_manager_appid != KSU_INVALID_UID);
-		pr_info(
-		    "track_throne: ksu_manager_appid=%d, KSU_INVALID_UID=%d\n",
-		    ksu_manager_appid, KSU_INVALID_UID);
+		manager_exist = (ksu_manager_appid != KSU_INVALID_UID);
 		if (!manager_exist) {
 #ifdef CONFIG_KSU_SUPERKEY
 			extern void ksu_superkey_register_prctl_kprobe(void);
 			ksu_superkey_register_prctl_kprobe();
 #endif // #ifdef CONFIG_KSU_SUPERKEY
 		}
-		/*
-		 * Always rescan /data/app to avoid stale manager_appid
-		 * after app reinstall / appid reuse.
-		 */
+	}
+
+	need_search = !manager_exist;
+
+	if (need_search) {
 		pr_info("Searching for manager(s)...\n");
 		search_manager("/data/app", 2, &uid_list);
 		pr_info("Manager search finished\n");

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -482,7 +482,15 @@ void track_throne(bool prune_only)
 		if (chr != '\n')
 			continue;
 
-		count = kernel_read(fp, buf, sizeof(buf), &line_start);
+		size_t line_len = pos - line_start - 1; // Exclude '\n'
+		if (line_len >= sizeof(buf)) {
+			// Line too long, skip it
+			line_start = pos;
+			continue;
+		}
+
+		count = kernel_read(fp, buf, line_len, &line_start);
+		buf[line_len] = '\0'; // Null-terminate the string
 
 		struct uid_data *data =
 		    kzalloc(sizeof(struct uid_data), GFP_ATOMIC);

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -575,12 +575,27 @@ out:
 	}
 }
 
+/*
+ * LKM: Delayed manager search when loaded after boot (packages.list may
+ * already exist and won't trigger fsnotify). Schedule a delayed search.
+ */
+static struct delayed_work throne_search_work;
+
+static void do_throne_search(struct work_struct *work)
+{
+	pr_info("throne_tracker: delayed search for manager...\n");
+	track_throne(false);
+}
+
 void ksu_throne_tracker_init()
 {
-	// nothing to do
+	INIT_DELAYED_WORK(&throne_search_work, do_throne_search);
+	schedule_delayed_work(&throne_search_work, msecs_to_jiffies(3000));
+	pr_info("throne_tracker: init, scheduled manager search in 3s\n");
 }
 
 void ksu_throne_tracker_exit(void)
 {
-	// nothing to do
+	cancel_delayed_work_sync(&throne_search_work);
+	pr_info("throne_tracker: exit\n");
 }

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -36,8 +36,47 @@ static void update_primary_manager(void)
 
 void ksu_set_manager_appid_for_index(uid_t appid, int signature_index)
 {
+	int i;
+
 	if (signature_index < 0 || signature_index >= KSU_MAX_MANAGER_KEYS)
 		return;
+
+	/*
+	 * Keep multi-manager coexistence stable:
+	 * - If this appid is already present in any slot, reuse that slot.
+	 * - If target signature slot is occupied by another app, place this app
+	 *   into an empty slot instead of overwriting.
+	 */
+	for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++) {
+		if (ksu_manager_appids[i] == appid) {
+			ksu_manager_appids[i] = appid;
+			locked_manager_appids[i] = appid;
+			update_primary_manager();
+			return;
+		}
+	}
+
+	if (ksu_manager_appids[signature_index] == KSU_INVALID_UID ||
+	    ksu_manager_appids[signature_index] == appid) {
+		ksu_manager_appids[signature_index] = appid;
+		locked_manager_appids[signature_index] = appid;
+		update_primary_manager();
+		return;
+	}
+
+	for (i = 0; i < KSU_MAX_MANAGER_KEYS; i++) {
+		if (ksu_manager_appids[i] == KSU_INVALID_UID) {
+			ksu_manager_appids[i] = appid;
+			locked_manager_appids[i] = appid;
+			pr_info("Manager slot collision on signature_index=%d, "
+				"placed appid=%u into slot=%d\n",
+				signature_index, appid, i);
+			update_primary_manager();
+			return;
+		}
+	}
+
+	/* No empty slot left (current max is 2), keep historical behavior. */
 	ksu_manager_appids[signature_index] = appid;
 	locked_manager_appids[signature_index] = appid;
 	update_primary_manager();

--- a/manager/app/src/main/cpp/ksu.c
+++ b/manager/app/src/main/cpp/ksu.c
@@ -134,8 +134,10 @@ bool is_lkm_mode() {
 }
 
 bool is_manager() {
-  auto info = get_info();
-  if (info.version > 0) {
+  // Do a fresh query to avoid stale cached flags after kernel crowns manager.
+  struct ksu_get_info_cmd info = {};
+  if (ksuctl(KSU_IOCTL_GET_INFO, &info) == 0 && info.version > 0) {
+    g_version = info; // keep cache coherent for subsequent calls
     return (info.flags & 0x2) != 0;
   }
   // Legacy Compatible

--- a/manager/app/src/main/cpp/ksu.c
+++ b/manager/app/src/main/cpp/ksu.c
@@ -59,9 +59,31 @@ static inline int scan_driver_fd() {
   return found;
 }
 
+static inline int request_driver_fd_via_prctl() {
+  struct ksu_prctl_get_fd_cmd cmd = {
+      .result = -1,
+      .fd = -1,
+  };
+
+  /*
+   * Ask kernel for a dedicated KSU driver fd when none is inherited.
+   * This is required for manager coexistence, where one manager process
+   * may not have an existing [ksu_driver] fd to scan from /proc/self/fd.
+   */
+  long ret = prctl(KSU_PRCTL_GET_FD, &cmd, 0, 0, 0);
+  (void)ret;
+  if (cmd.result == 0 && cmd.fd >= 0) {
+    return cmd.fd;
+  }
+  return -1;
+}
+
 static int ksuctl(unsigned long op, void *arg) {
   if (fd < 0) {
     fd = scan_driver_fd();
+    if (fd < 0) {
+      fd = request_driver_fd_via_prctl();
+    }
   }
   return ioctl(fd, op, arg);
 }

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Flash.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Flash.kt
@@ -270,7 +270,7 @@ fun FlashScreen(navigator: DestinationsNavigator, flashIt: FlashIt) {
                     }
                 }
 
-                // 仅 shouldAutoExit 时自动退出；作为打开方弝进入时坜留在界面让用户查看结果
+                // ? shouldAutoExit ???????????????????????????
                 if (shouldAutoExit) {
                     scope.launch {
                         while (shouldWarningUserMetaModule) {
@@ -779,7 +779,8 @@ sealed class FlashIt : Parcelable {
         val ota: Boolean,
         val partition: String? = null,
         val superKey: String? = null,
-        val signatureBypass: Boolean = false
+        val signatureBypass: Boolean = false,
+        val hymofsInCpio: Boolean = false
     ) : FlashIt()
     data class FlashModule(val uri: Uri) : FlashIt()
     data class FlashModules(val uris: List<Uri>, val currentIndex: Int = 0) : FlashIt()
@@ -812,6 +813,7 @@ fun flashIt(
             flashIt.partition,
             flashIt.superKey,
             flashIt.signatureBypass,
+            flashIt.hymofsInCpio,
             onFinish,
             onStdout,
             onStderr

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/screen/Install.kt
@@ -115,6 +115,8 @@ fun InstallScreen(
     var showSuperKeyInput by remember { mutableStateOf(false) }
     // Signature bypass - when enabled, only SuperKey authentication works
     var signatureBypass by remember { mutableStateOf(false) }
+    // Experimental: embed HymoFS LKM in cpio (init_boot)
+    var hymofsInCpio by remember { mutableStateOf(false) }
 
     val onInstall = {
         installMethod?.let { method ->
@@ -126,7 +128,8 @@ fun InstallScreen(
                 ota = isOta,
                 partition = partitionSelection,
                 superKey = superKey.ifBlank { null },
-                signatureBypass = signatureBypass
+                signatureBypass = signatureBypass,
+                hymofsInCpio = hymofsInCpio
             )
             navigator.navigate(FlashScreenDestination(flashIt))
         }
@@ -455,6 +458,38 @@ fun InstallScreen(
                         stringResource(id = R.string.install_next),
                         style = MaterialTheme.typography.bodyMedium
                     )
+                }
+
+                // Experimental: embed HymoFS in init_boot
+                AnimatedVisibility(
+                    visible = installMethod != null,
+                    enter = fadeIn() + expandVertically(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(id = R.string.hymofs_in_cpio_title),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = stringResource(id = R.string.hymofs_in_cpio_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = hymofsInCpio,
+                            onCheckedChange = { hymofsInCpio = it }
+                        )
+                    }
                 }
             }
         }

--- a/manager/app/src/main/java/com/anatdx/yukisu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/com/anatdx/yukisu/ui/util/KsuCli.kt
@@ -498,6 +498,7 @@ fun installBoot(
     partition: String?,
     superKey: String? = null,
     signatureBypass: Boolean = false,
+    hymofsInCpio: Boolean = false,  // Experimental: embed HymoFS LKM in cpio, load after KernelSU
     onFinish: (Boolean, Int) -> Unit,
     onStdout: (String) -> Unit,
     onStderr: (String) -> Unit,
@@ -580,6 +581,10 @@ fun installBoot(
 
     partition?.let { part ->
         cmd += " --partition $part"
+    }
+
+    if (hymofsInCpio) {
+        cmd += " --hymofs"
     }
 
     val result = flashWithIO("${getKsuDaemonPath()} $cmd", onStdout, onStderr)

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -115,7 +115,7 @@
     <string name="install_inactive_slot_warning">将在重启后强制切换到另一个槽位！注意只能在 OTA 更新完成后的重启之前使用。</string>
     <string name="install_next">下一步</string>
     <string name="install_select_partition">选择分区</string>
-    <string name="hymofs_in_cpio_title">实验：将 HymoFS 刷入 init_boot</string>
+    <string name="hymofs_in_cpio_title">实验：将 HymoFS 刷入 cpio</string>
     <string name="hymofs_in_cpio_desc">开启后，修补时会加入 HymoFS LKM，开机时紧随 KernelSU 加载</string>
     <string name="install_upload_lkm_file">使用本地 LKM 文件</string>
     <string name="install_only_support_ko_file">仅支持选择 .ko 文件</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -115,6 +115,8 @@
     <string name="install_inactive_slot_warning">将在重启后强制切换到另一个槽位！注意只能在 OTA 更新完成后的重启之前使用。</string>
     <string name="install_next">下一步</string>
     <string name="install_select_partition">选择分区</string>
+    <string name="hymofs_in_cpio_title">实验：将 HymoFS 刷入 init_boot</string>
+    <string name="hymofs_in_cpio_desc">开启后，修补时会加入 HymoFS LKM，开机时紧随 KernelSU 加载</string>
     <string name="install_upload_lkm_file">使用本地 LKM 文件</string>
     <string name="install_only_support_ko_file">仅支持选择 .ko 文件</string>
     <string name="select_file_tip">建议选择 %1$s 分区镜像</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -157,7 +157,7 @@
     <string name="install_inactive_slot_warning">Your device will be **FORCED** to boot to the current inactive slot after a reboot!\nOnly use this option after OTA is done.\nContinue?</string>
     <string name="install_next">Next</string>
     <string name="install_select_partition">Select partition</string>
-    <string name="hymofs_in_cpio_title">Experimental: Embed HymoFS in init_boot</string>
+    <string name="hymofs_in_cpio_title">Experimental: Embed HymoFS in cpio</string>
     <string name="hymofs_in_cpio_desc">When enabled, HymoFS LKM will be added to cpio and loaded after KernelSU at boot</string>
     <string name="install_upload_lkm_file">Use local LKM file</string>
     <string name="install_only_support_ko_file">Only .ko files are supported</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -157,6 +157,8 @@
     <string name="install_inactive_slot_warning">Your device will be **FORCED** to boot to the current inactive slot after a reboot!\nOnly use this option after OTA is done.\nContinue?</string>
     <string name="install_next">Next</string>
     <string name="install_select_partition">Select partition</string>
+    <string name="hymofs_in_cpio_title">Experimental: Embed HymoFS in init_boot</string>
+    <string name="hymofs_in_cpio_desc">When enabled, HymoFS LKM will be added to cpio and loaded after KernelSU at boot</string>
     <string name="install_upload_lkm_file">Use local LKM file</string>
     <string name="install_only_support_ko_file">Only .ko files are supported</string>
     <string name="select_file_tip">%1$s partition image is recommended</string>

--- a/userspace/ksud/src/boot/boot_patch.cpp
+++ b/userspace/ksud/src/boot/boot_patch.cpp
@@ -682,13 +682,15 @@ int boot_patch_impl(const std::vector<std::string>& args) {
         }
     }
 
-    // Inject SuperKey if specified
+    // Always inject verification mode (and SuperKey hash if set).
+    // Pure signature mode (no superkey) still needs flags=0 to be explicitly written,
+    // otherwise the LKM may have stale/wrong values and signature verification fails.
     if (!parsed.superkey.empty()) {
         printf("- Injecting SuperKey into LKM\n");
-        inject_superkey_to_lkm(kmod_file, parsed.superkey, parsed.signature_bypass);
     } else if (parsed.signature_bypass) {
         printf("- Warning: signature_bypass requires superkey to be set, ignoring\n");
     }
+    inject_superkey_to_lkm(kmod_file, parsed.superkey, parsed.signature_bypass);
 
     // Inject LKM priority setting
     printf("- Configuring LKM priority\n");

--- a/userspace/ksud/src/boot/boot_patch.cpp
+++ b/userspace/ksud/src/boot/boot_patch.cpp
@@ -39,6 +39,17 @@ constexpr uint64_t SUPERKEY_VERIFICATION_KEY_ONLY = 2;
 // "LKMPRIO" in hex (little-endian)
 constexpr uint64_t LKM_PRIORITY_MAGIC = 0x4F4952504D4B4C;
 
+// Arch suffix for HymoFS LKM asset name (must match lkm.cpp)
+#if defined(__aarch64__)
+#define HYMO_ARCH_SUFFIX "_arm64"
+#elif defined(__arm__)
+#define HYMO_ARCH_SUFFIX "_armv7"
+#elif defined(__x86_64__)
+#define HYMO_ARCH_SUFFIX "_x86_64"
+#else
+#define HYMO_ARCH_SUFFIX "_arm64"
+#endif  // #if defined(__aarch64__)
+
 namespace {
 
 // LZ4 legacy ramdisk magic (reject before cpio to avoid huge cache/hang).
@@ -403,6 +414,8 @@ struct BootPatchArgs {
     std::string kmi;                // --kmi
     std::string partition;          // --partition
     std::string out_name;           // --out-name
+    bool hymofs_in_cpio =
+        false;  // --hymofs (experimental: embed HymoFS LKM in cpio, load after KernelSU)
 };
 
 namespace {
@@ -459,6 +472,8 @@ BootPatchArgs parse_boot_patch_args(const std::vector<std::string>& args) {
         } else if (arg == "--out-name") {
             if (i + 1 < args.size())
                 result.out_name = args[++i];
+        } else if (arg == "--hymofs") {
+            result.hymofs_in_cpio = true;
         }
     }
 
@@ -841,6 +856,20 @@ int boot_patch_impl(const std::vector<std::string>& args) {
         return 1;
     }
 
+    // Experimental: add HymoFS LKM to cpio (load after KernelSU in ksuinit)
+    if (parsed.hymofs_in_cpio) {
+        const std::string hymofs_asset = kmi + HYMO_ARCH_SUFFIX "_hymofs_lkm.ko";
+        const std::string hymofs_file = workdir + "/hymofs.ko";
+        if (copy_asset_to_file(hymofs_asset, hymofs_file)) {
+            printf("- Adding HymoFS LKM (experimental)\n");
+            if (!do_cpio_cmd(magiskboot, workdir, ramdisk, "add 0644 hymofs.ko hymofs.ko")) {
+                LOGW("Failed to add hymofs.ko to cpio");
+            }
+        } else {
+            LOGW("HymoFS LKM asset %s not found, skipping", hymofs_asset.c_str());
+        }
+    }
+
     // Backup if flashing and not already patched
     if (!already_patched && parsed.flash) {
         if (!do_backup(magiskboot, workdir, ramdisk, bootimage)) {
@@ -1128,6 +1157,13 @@ int boot_restore(const std::vector<std::string>& args) {
     if (!from_backup) {
         // Remove kernelsu.ko
         do_cpio_cmd(magiskboot, workdir, ramdisk, "rm kernelsu.ko");
+
+        // Remove hymofs.ko if present (experimental cpio embed)
+        auto hymofs_exists =
+            exec_command_magiskboot(magiskboot, {"cpio", ramdisk, "exists hymofs.ko"}, workdir);
+        if (hymofs_exists.exit_code == 0) {
+            do_cpio_cmd(magiskboot, workdir, ramdisk, "rm hymofs.ko");
+        }
 
         // Restore init if init.real exists
         auto init_real_exists =

--- a/userspace/ksud/src/boot/boot_patch.cpp
+++ b/userspace/ksud/src/boot/boot_patch.cpp
@@ -858,7 +858,7 @@ int boot_patch_impl(const std::vector<std::string>& args) {
         return 1;
     }
 
-    // Experimental: add HymoFS LKM to cpio (load after KernelSU in ksuinit)
+    // Experimental: add or remove HymoFS LKM in cpio (load after KernelSU in ksuinit)
     if (parsed.hymofs_in_cpio) {
         const std::string hymofs_asset = kmi + HYMO_ARCH_SUFFIX "_hymofs_lkm.ko";
         const std::string hymofs_file = workdir + "/hymofs.ko";
@@ -869,6 +869,14 @@ int boot_patch_impl(const std::vector<std::string>& args) {
             }
         } else {
             LOGW("HymoFS LKM asset %s not found, skipping", hymofs_asset.c_str());
+        }
+    } else {
+        // User disabled HymoFS: remove hymofs.ko from cpio if it was previously
+        // embedded (otherwise it stays forever after re-patch without the option).
+        auto hymofs_exists =
+            exec_command_magiskboot(magiskboot, {"cpio", ramdisk, "exists hymofs.ko"}, workdir);
+        if (hymofs_exists.exit_code == 0) {
+            do_cpio_cmd(magiskboot, workdir, ramdisk, "rm hymofs.ko");
         }
     }
 

--- a/userspace/ksuinit/src/init.cpp
+++ b/userspace/ksuinit/src/init.cpp
@@ -194,6 +194,14 @@ bool init() {
         if (!load_module("/kernelsu.ko")) {
             KLOGE("Cannot load kernelsu.ko");
         }
+
+        // Experimental: load HymoFS LKM if present in cpio (must be after kernelsu.ko)
+        if (access("/hymofs.ko", F_OK) == 0) {
+            KLOGI("Loading hymofs.ko..");
+            if (!load_module("/hymofs.ko")) {
+                KLOGW("Cannot load hymofs.ko (non-fatal)");
+            }
+        }
     }
     // /proc and /sys are unmounted here
 


### PR DESCRIPTION
- Added a new option to embed HymoFS LKM in cpio during installation, allowing for loading after KernelSU.
- Updated the Flash and Install screens to include a toggle for the HymoFS embedding feature, enhancing user control.
- Introduced new string resources for HymoFS embedding in both English and Chinese, improving localization.
- Enhanced the boot patching process to handle the new HymoFS embedding functionality, ensuring proper integration.
- Improved error handling and logging for HymoFS loading in the init process, providing better diagnostics.